### PR TITLE
update war.js -- do not run mainGame() automatically at page load.

### DIFF
--- a/war.js
+++ b/war.js
@@ -82,5 +82,5 @@ var mainGame = function(){
 		
 };
 
-mainGame(); //Have method start when user click "start button, restart button"
+//mainGame(); //Have method start when user click "start button, restart button"
 


### PR DESCRIPTION
mainGame(); at the bottom of war.js is now commented out, so that that function is not called at page load.
mainGame(); now only gets called by our click handler on the "Start Game" button.

Awesome Job Guys !
